### PR TITLE
feat: support asyncpg pool

### DIFF
--- a/muffin_peewee/__init__.py
+++ b/muffin_peewee/__init__.py
@@ -164,7 +164,7 @@ class Plugin(BasePlugin):
         factory = lambda: copy(default) if isinstance(default, (dict, list)) else default  # noqa: E731
 
         backend = self.manager.backend
-        if backend.name == "asyncpg":
+        if backend.name in ("asyncpg", "asyncpg+pool"):
             return JSONAsyncPGField(default=factory, **kwargs)
 
         if backend.db_type == "postgresql":

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -50,9 +50,7 @@ async def test_json_field_returns_correct_backend_type(db: Plugin):
     expected_types = {
         "aiosqlite": JSONSQLiteField,
         "aiopg": JSONPGField,
-        "aiopg+pool": JSONPGField,
         "asyncpg": JSONAsyncPGField,
-        "asyncpg+pool": JSONAsyncPGField,
     }
 
     expected = expected_types.get(backend)
@@ -60,6 +58,18 @@ async def test_json_field_returns_correct_backend_type(db: Plugin):
         pytest.fail(f"Unexpected backend: {backend}")
 
     assert isinstance(db.JSONField({}), expected)
+
+
+async def test_json_field_returns_correct_backend_type_for_asyncpg_pool(app):
+    import muffin_peewee
+
+    db = muffin_peewee.Plugin(
+        app,
+        connection="asyncpg+pool://test:test@localhost:5432/tests",
+        connection_params={"json": True},
+    )
+    assert db.manager.backend.name == "asyncpg+pool"
+    assert isinstance(db.JSONField({}), JSONAsyncPGField)
 
 
 async def test_json_field_defaults_are_independent(db: Plugin):


### PR DESCRIPTION
Fixes #

When using asyncpg+pool:// as the connection string, Plugin.JSONField() did not recognize the backend and fell back to JSONPGField instead of JSONAsyncPGField.

Changes are in this PR

- Treat asyncpg+pool the same as asyncpg in Plugin.JSONField() so pooled connections get JSONAsyncPGField
- Add a test for asyncpg+pool
cc/ @klen
